### PR TITLE
rename "Implementation" chapters to "Implementation guide"

### DIFF
--- a/doc/windows-djm-850-setting-utility/mixer-input-tab/README.md
+++ b/doc/windows-djm-850-setting-utility/mixer-input-tab/README.md
@@ -8,7 +8,7 @@
 - [Frame details](#frame-details)
     - [Request](#request)
     - [Response](#response)
-- [Implementation](#implementation)
+- [Implementation guide](#implementation-guide)
     - [Crafting requests](#crafting-requests)
     - [Reading responses](#reading-responses)
 
@@ -248,7 +248,7 @@ response data. Here, it indicates that all the switches are on the left
 (`CD/Line` position). See the [switches positions map](#switches-positions-map)
 chapter for more details.
 
-## Implementation
+## Implementation guide
 
 From the above frame details and response data analysis, we can issue some
 details in order to implement the features of the `Mixer input` tab.

--- a/doc/windows-djm-850-setting-utility/mixer-output-tab/README.md
+++ b/doc/windows-djm-850-setting-utility/mixer-output-tab/README.md
@@ -12,7 +12,7 @@
     - [USB output audio routing response](#usb-output-audio-routing-response)
     - [USB output level request](#usb-output-level-request)
     - [USB output level response](#usb-output-level-response)
-- [Implementation](#implementation)
+- [Implementation guide](#implementation-guide)
     - [Crafting requests to set USB output audio routing](#crafting-requests-to-set-usb-output-audio-routing)
     - [Crafting requests to set USB output level](#crafting-requests-to-set-usb-output-level)
     - [Reading responses](#reading-responses)
@@ -424,7 +424,7 @@ USB URB
     [bInterfaceClass: Unknown (0xffff)]
 ```
 
-## Implementation
+## Implementation guide
 
 From the above frame details and response data analysis, we can issue some
 details in order to implement the features of the `Mixer output` tab.

--- a/doc/windows-djm-850-setting-utility/plugging-in-device/README.md
+++ b/doc/windows-djm-850-setting-utility/plugging-in-device/README.md
@@ -6,7 +6,7 @@
 - [USB frame capture workflow](#usb-frame-capture-workflow)
 - [Discussion details](#discussion-details)
 - [Configuration storage](#configuration-storage)
-- [Implementation](#implementation)
+- [Implementation guide](#implementation-guide)
 
 ## Presentation
 
@@ -80,7 +80,7 @@ values sent to the device. I don't know why the values differ, but this is an
 implementation detail of the way the Setting Utility stores the config, and what
 really matters here is that we are now aware that this config is stored.
 
-## Implementation
+## Implementation guide
 
 The clone of the Setting Utility should also send the latest used USB output
 configuration to the device when it launches and the device is plugged in.


### PR DESCRIPTION
As these chapters do not contain any implementation, but they expose
guidelines for implementation instead.